### PR TITLE
Feature/apps 2441 update pending charges logic for tag on stats

### DIFF
--- a/src/components/casehistory/CaseHistory.js
+++ b/src/components/casehistory/CaseHistory.js
@@ -7,7 +7,6 @@ import { List, Map } from 'immutable';
 
 import ChargeHistoryStats from './ChargeHistoryStats';
 import CaseHistoryList from './CaseHistoryList';
-import { currentPendingCharges } from '../../utils/CaseUtils';
 
 const CaseHistoryWrapper = styled.div`
   hr {
@@ -17,18 +16,19 @@ const CaseHistoryWrapper = styled.div`
 `;
 
 type Props = {
-  caseNumbersToAssociationId :Map<*, *>,
-  caseHistoryForMostRecentPSA :List<*>,
-  chargeHistoryForMostRecentPSA :Map<*, *>,
-  caseHistoryNotForMostRecentPSA :List<*>,
-  chargeHistoryNotForMostRecentPSA :Map<*, *>,
-  chargeHistory :Map<*, *>,
-  loading :boolean,
-  modal :boolean,
-  overview :boolean,
-  psaPermissions :boolean,
-  addCaseToPSA :() => void,
-  removeCaseFromPSA :() => void,
+  caseNumbersToAssociationId :Map;
+  caseHistoryForMostRecentPSA :List;
+  chargeHistoryForMostRecentPSA :Map;
+  caseHistoryNotForMostRecentPSA :List;
+  chargeHistoryNotForMostRecentPSA :Map;
+  loading :boolean;
+  modal :boolean;
+  overview :boolean;
+  personNeighbors :Map;
+  psaNeighbors :Map;
+  psaPermissions :boolean;
+  addCaseToPSA :() => void;
+  removeCaseFromPSA :() => void;
 };
 
 const CaseHistory = ({
@@ -37,16 +37,15 @@ const CaseHistory = ({
   chargeHistoryForMostRecentPSA,
   caseHistoryNotForMostRecentPSA,
   chargeHistoryNotForMostRecentPSA,
-  chargeHistory,
   loading,
   modal,
   overview,
   addCaseToPSA,
+  personNeighbors,
+  psaNeighbors,
   psaPermissions,
   removeCaseFromPSA
 } :Props) => {
-
-  const pendingCharges = currentPendingCharges(chargeHistoryForMostRecentPSA);
 
   return (
     <CaseHistoryWrapper modal={modal}>
@@ -54,8 +53,8 @@ const CaseHistory = ({
         ? null
         : (
           <ChargeHistoryStats
-              pendingCharges={pendingCharges}
-              chargeHistory={chargeHistory} />
+              personNeighbors={personNeighbors}
+              psaNeighbors={psaNeighbors} />
         )}
       <CaseHistoryList
           psaPermissions={psaPermissions}

--- a/src/components/casehistory/CaseHistory.js
+++ b/src/components/casehistory/CaseHistory.js
@@ -43,32 +43,29 @@ const CaseHistory = ({
   psaNeighbors,
   psaPermissions,
   removeCaseFromPSA
-} :Props) => {
-
-  return (
-    <CaseHistoryWrapper modal={modal}>
-      <ChargeHistoryStats
-          personNeighbors={personNeighbors}
-          psaNeighbors={psaNeighbors} />
-      <CaseHistoryList
-          addCaseToPSA={addCaseToPSA}
-          caseHistory={caseHistoryForMostRecentPSA}
-          caseNumbersToAssociationId={caseNumbersToAssociationId}
-          chargeHistory={chargeHistoryForMostRecentPSA}
-          loading={loading}
-          modal={modal}
-          pendingCases
-          psaPermissions={psaPermissions}
-          removeCaseFromPSA={removeCaseFromPSA}
-          title="Pending Cases on Arrest Date for Current PSA" />
-      <CaseHistoryList
-          caseHistory={caseHistoryNotForMostRecentPSA}
-          chargeHistory={chargeHistoryNotForMostRecentPSA}
-          loading={loading}
-          modal={modal}
-          title="Case History" />
-    </CaseHistoryWrapper>
-  );
-};
+} :Props) => (
+  <CaseHistoryWrapper modal={modal}>
+    <ChargeHistoryStats
+        personNeighbors={personNeighbors}
+        psaNeighbors={psaNeighbors} />
+    <CaseHistoryList
+        addCaseToPSA={addCaseToPSA}
+        caseHistory={caseHistoryForMostRecentPSA}
+        caseNumbersToAssociationId={caseNumbersToAssociationId}
+        chargeHistory={chargeHistoryForMostRecentPSA}
+        loading={loading}
+        modal={modal}
+        pendingCases
+        psaPermissions={psaPermissions}
+        removeCaseFromPSA={removeCaseFromPSA}
+        title="Pending Cases on Arrest Date for Current PSA" />
+    <CaseHistoryList
+        caseHistory={caseHistoryNotForMostRecentPSA}
+        chargeHistory={chargeHistoryNotForMostRecentPSA}
+        loading={loading}
+        modal={modal}
+        title="Case History" />
+  </CaseHistoryWrapper>
+);
 
 export default CaseHistory;

--- a/src/components/casehistory/CaseHistory.js
+++ b/src/components/casehistory/CaseHistory.js
@@ -24,7 +24,6 @@ type Props = {
   chargeHistoryNotForMostRecentPSA :Map;
   loading :boolean;
   modal :boolean;
-  overview :boolean;
   personNeighbors :Map;
   psaNeighbors :Map;
   psaPermissions :boolean;
@@ -40,7 +39,6 @@ const CaseHistory = ({
   chargeHistoryNotForMostRecentPSA,
   loading,
   modal,
-  overview,
   personNeighbors,
   psaNeighbors,
   psaPermissions,
@@ -49,13 +47,9 @@ const CaseHistory = ({
 
   return (
     <CaseHistoryWrapper modal={modal}>
-      {
-        !overview && (
-          <ChargeHistoryStats
-              personNeighbors={personNeighbors}
-              psaNeighbors={psaNeighbors} />
-        )
-      }
+      <ChargeHistoryStats
+          personNeighbors={personNeighbors}
+          psaNeighbors={psaNeighbors} />
       <CaseHistoryList
           addCaseToPSA={addCaseToPSA}
           caseHistory={caseHistoryForMostRecentPSA}

--- a/src/components/casehistory/CaseHistory.js
+++ b/src/components/casehistory/CaseHistory.js
@@ -49,13 +49,13 @@ const CaseHistory = ({
 
   return (
     <CaseHistoryWrapper modal={modal}>
-      { overview
-        ? null
-        : (
+      {
+        overview && (
           <ChargeHistoryStats
               personNeighbors={personNeighbors}
               psaNeighbors={psaNeighbors} />
-        )}
+        )
+      }
       <CaseHistoryList
           psaPermissions={psaPermissions}
           pendingCases

--- a/src/components/casehistory/CaseHistory.js
+++ b/src/components/casehistory/CaseHistory.js
@@ -16,10 +16,11 @@ const CaseHistoryWrapper = styled.div`
 `;
 
 type Props = {
-  caseNumbersToAssociationId :Map;
+  addCaseToPSA :() => void;
   caseHistoryForMostRecentPSA :List;
-  chargeHistoryForMostRecentPSA :Map;
   caseHistoryNotForMostRecentPSA :List;
+  caseNumbersToAssociationId :Map;
+  chargeHistoryForMostRecentPSA :Map;
   chargeHistoryNotForMostRecentPSA :Map;
   loading :boolean;
   modal :boolean;
@@ -27,20 +28,19 @@ type Props = {
   personNeighbors :Map;
   psaNeighbors :Map;
   psaPermissions :boolean;
-  addCaseToPSA :() => void;
   removeCaseFromPSA :() => void;
 };
 
 const CaseHistory = ({
-  caseNumbersToAssociationId,
+  addCaseToPSA,
   caseHistoryForMostRecentPSA,
-  chargeHistoryForMostRecentPSA,
   caseHistoryNotForMostRecentPSA,
+  caseNumbersToAssociationId,
+  chargeHistoryForMostRecentPSA,
   chargeHistoryNotForMostRecentPSA,
   loading,
   modal,
   overview,
-  addCaseToPSA,
   personNeighbors,
   psaNeighbors,
   psaPermissions,
@@ -57,22 +57,22 @@ const CaseHistory = ({
         )
       }
       <CaseHistoryList
-          psaPermissions={psaPermissions}
-          pendingCases
           addCaseToPSA={addCaseToPSA}
-          removeCaseFromPSA={removeCaseFromPSA}
-          caseNumbersToAssociationId={caseNumbersToAssociationId}
-          loading={loading}
-          title="Pending Cases on Arrest Date for Current PSA"
           caseHistory={caseHistoryForMostRecentPSA}
+          caseNumbersToAssociationId={caseNumbersToAssociationId}
           chargeHistory={chargeHistoryForMostRecentPSA}
-          modal={modal} />
-      <CaseHistoryList
           loading={loading}
-          title="Case History"
+          modal={modal}
+          pendingCases
+          psaPermissions={psaPermissions}
+          removeCaseFromPSA={removeCaseFromPSA}
+          title="Pending Cases on Arrest Date for Current PSA" />
+      <CaseHistoryList
           caseHistory={caseHistoryNotForMostRecentPSA}
           chargeHistory={chargeHistoryNotForMostRecentPSA}
-          modal={modal} />
+          loading={loading}
+          modal={modal}
+          title="Case History" />
     </CaseHistoryWrapper>
   );
 };

--- a/src/components/casehistory/CaseHistory.js
+++ b/src/components/casehistory/CaseHistory.js
@@ -50,7 +50,7 @@ const CaseHistory = ({
   return (
     <CaseHistoryWrapper modal={modal}>
       {
-        overview && (
+        !overview && (
           <ChargeHistoryStats
               personNeighbors={personNeighbors}
               psaNeighbors={psaNeighbors} />

--- a/src/components/casehistory/CaseHistoryList.js
+++ b/src/components/casehistory/CaseHistoryList.js
@@ -16,6 +16,8 @@ import { getEntityProperties, getFirstNeighborValue } from '../../utils/DataUtil
 import { PROPERTY_TYPES } from '../../utils/consts/DataModelConsts';
 import { Count, NoResults, Title } from '../../utils/Layout';
 
+const TERMINATED = 'Terminated';
+
 const {
   CASE_ID,
   ENTITY_KEY_ID,
@@ -156,10 +158,10 @@ const CaseHistoryList = ({
                 )
               }
               {
-                (caseStatus === 'Terminated')
+                (caseStatus === TERMINATED)
                 && (
                   <InfoItem modal={modal}>
-                    <Tag mode="danger">{`Terminated (${formatDateTime(lastUpdated)})`}</Tag>
+                    <Tag mode="danger">{`${TERMINATED} (${formatDateTime(lastUpdated)})`}</Tag>
                   </InfoItem>
                 )
               }

--- a/src/components/casehistory/CaseHistoryList.js
+++ b/src/components/casehistory/CaseHistoryList.js
@@ -147,18 +147,22 @@ const CaseHistoryList = ({
             <InfoRowContainer>
               <InfoItem modal={modal}>{`Case Number: ${caseId}`}</InfoItem>
               <InfoItem modal={modal}>{`File Date: ${formattedFileDate}`}</InfoItem>
-              <InfoItem modal={modal}>
-                { (psaPermissions && hasBeenUpdated)
-                  ? <Tag mode="danger">Updated</Tag>
-                  : null}
-              </InfoItem>
-              <InfoItem modal={modal}>
-                {
-                  (caseStatus === 'Terminated')
-                    ? <Tag mode="danger">{`Terminated (${formatDateTime(lastUpdated)})`}</Tag>
-                    : null
-                }
-              </InfoItem>
+              {
+                (psaPermissions && hasBeenUpdated)
+                && (
+                  <InfoItem modal={modal}>
+                    <Tag mode="danger">Updated</Tag>
+                  </InfoItem>
+                )
+              }
+              {
+                (caseStatus === 'Terminated')
+                && (
+                  <InfoItem modal={modal}>
+                    <Tag mode="danger">{`Terminated (${formatDateTime(lastUpdated)})`}</Tag>
+                  </InfoItem>
+                )
+              }
             </InfoRowContainer>
             { caseNumbersToAssociationId ? addCaseToPSAButton(caseEKID, caseId) : null }
           </InfoRow>

--- a/src/components/casehistory/CaseHistoryList.js
+++ b/src/components/casehistory/CaseHistoryList.js
@@ -11,15 +11,17 @@ import { Button, Tag } from 'lattice-ui-kit';
 import ChargeList from '../charges/ChargeList';
 import LoadingSpinner from '../LoadingSpinner';
 import { OL } from '../../utils/consts/Colors';
-import { formatDateList } from '../../utils/FormattingUtils';
+import { formatDateList, formatDateTime } from '../../utils/FormattingUtils';
 import { getEntityProperties, getFirstNeighborValue } from '../../utils/DataUtils';
 import { PROPERTY_TYPES } from '../../utils/consts/DataModelConsts';
 import { Count, NoResults, Title } from '../../utils/Layout';
 
 const {
-  ENTITY_KEY_ID,
   CASE_ID,
+  ENTITY_KEY_ID,
   FILE_DATE,
+  LAST_UPDATED_DATE,
+  CASE_STATUS,
 } = PROPERTY_TYPES;
 
 const InfoRow = styled.div`
@@ -131,8 +133,10 @@ const CaseHistoryList = ({
       const {
         [ENTITY_KEY_ID]: caseEKID,
         [CASE_ID]: caseId,
-        [FILE_DATE]: fileDate
-      } = getEntityProperties(caseObj, [ENTITY_KEY_ID, CASE_ID, FILE_DATE]);
+        [FILE_DATE]: fileDate,
+        [LAST_UPDATED_DATE]: lastUpdated,
+        [CASE_STATUS]: caseStatus,
+      } = getEntityProperties(caseObj, [ENTITY_KEY_ID, CASE_ID, FILE_DATE, LAST_UPDATED_DATE, CASE_STATUS]);
       const formattedFileDate = formatDateList([fileDate]);
       const charges = chargeHistory.get(caseId);
       const dateList = caseObj.get(PROPERTY_TYPES.FILE_DATE, List());
@@ -147,6 +151,13 @@ const CaseHistoryList = ({
                 { (psaPermissions && hasBeenUpdated)
                   ? <Tag mode="danger">Updated</Tag>
                   : null}
+              </InfoItem>
+              <InfoItem modal={modal}>
+                {
+                  (caseStatus === 'Terminated')
+                    ? <Tag mode="danger">{`Terminated (${formatDateTime(lastUpdated)})`}</Tag>
+                    : null
+                }
               </InfoItem>
             </InfoRowContainer>
             { caseNumbersToAssociationId ? addCaseToPSAButton(caseEKID, caseId) : null }

--- a/src/components/casehistory/CaseHistoryList.js
+++ b/src/components/casehistory/CaseHistoryList.js
@@ -6,7 +6,7 @@ import { List, Map } from 'immutable';
 import styled from 'styled-components';
 // $FlowFixMe
 import { DateTime } from 'luxon';
-import { Button } from 'lattice-ui-kit';
+import { Button, Tag } from 'lattice-ui-kit';
 
 import ChargeList from '../charges/ChargeList';
 import LoadingSpinner from '../LoadingSpinner';
@@ -14,12 +14,7 @@ import { OL } from '../../utils/consts/Colors';
 import { formatDateList } from '../../utils/FormattingUtils';
 import { getEntityProperties, getFirstNeighborValue } from '../../utils/DataUtils';
 import { PROPERTY_TYPES } from '../../utils/consts/DataModelConsts';
-import {
-  NoResults,
-  Title,
-  Count,
-  PendingChargeStatus
-} from '../../utils/Layout';
+import { Count, NoResults, Title } from '../../utils/Layout';
 
 const {
   ENTITY_KEY_ID,
@@ -150,7 +145,7 @@ const CaseHistoryList = ({
               <InfoItem modal={modal}>{`File Date: ${formattedFileDate}`}</InfoItem>
               <InfoItem modal={modal}>
                 { (psaPermissions && hasBeenUpdated)
-                  ? <PendingChargeStatus pendingCharges>Updated</PendingChargeStatus>
+                  ? <Tag mode="danger">Updated</Tag>
                   : null}
               </InfoItem>
             </InfoRowContainer>

--- a/src/components/casehistory/CaseHistoryList.js
+++ b/src/components/casehistory/CaseHistoryList.js
@@ -20,52 +20,52 @@ const TERMINATED = 'Terminated';
 
 const {
   CASE_ID,
+  CASE_STATUS,
   ENTITY_KEY_ID,
   FILE_DATE,
   LAST_UPDATED_DATE,
-  CASE_STATUS,
 } = PROPERTY_TYPES;
 
 const InfoRow = styled.div`
+  align-items: center;
   background-color: ${OL.GREY09};
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  align-items: center;
-  padding: 15px 30px 15px 0;
   margin: ${(props :Object) => (props.modal ? '0 -30px' : '0')};
+  padding: 15px 30px 15px 0;
 `;
 
 const TitleWrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
   align-items: center;
   border-bottom: ${(props :Object) => (props.modal ? `1px solid ${OL.GREY01}` : 'none')};
   border-top: ${(props :Object) => (props.modal ? `1px solid ${OL.GREY01}` : 'none')};
-  padding-left: 30px;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
   margin: ${(props :Object) => (props.modal ? '20px -30px 0' : 0)};
+  padding-left: 30px;
 `;
 
 const InfoItem = styled.div`
-  display: flex;
   align-items: center;
+  color: ${OL.GREY01};
+  display: flex;
   margin: ${(props :Object) => (props.modal ? '0 30px' : '0')};
   padding: ${(props :Object) => (props.modal ? '0' : '0 30px')};
-  color: ${OL.GREY01};
 `;
 
 const CaseHistoryContainer = styled.div`
-  width: ${(props :Object) => (props.modal ? 'auto' : '100%')};
   height: 100%;
+  width: ${(props :Object) => (props.modal ? 'auto' : '100%')};
 `;
 
 const StyledSpinner = styled(LoadingSpinner)`
-  margin: ${(props :Object) => (props.modal ? '0 -30px 30px' : '0')};
-  display: flex;
-  justify-content: center;
   align-items: center;
+  display: flex;
   height: 100px;
+  justify-content: center;
+  margin: ${(props :Object) => (props.modal ? '0 -30px 30px' : '0')};
   width: 100%;
 `;
 
@@ -75,31 +75,31 @@ const InfoRowContainer = styled.div`
 `;
 
 type Props = {
-  addCaseToPSA ?:(caseEKID :UUID) => void,
+  addCaseToPSA ?:(caseEKID :UUID) => void;
+  caseHistory :List;
+  caseNumbersToAssociationId :Map;
+  chargeHistory :Map;
+  isCompact ?:boolean;
+  loading :boolean;
+  modal ?:boolean;
+  pendingCases ?:boolean;
+  psaPermissions ?:boolean;
   removeCaseFromPSA ?:(associationEKID :UUID) => void,
-  caseHistory :List<*>,
-  chargeHistory :Map<*, *>,
-  caseNumbersToAssociationId :Map<*, *>,
-  loading :boolean,
-  modal ?:boolean,
-  pendingCases ?:boolean,
-  psaPermissions ?:boolean,
-  title :string,
-  isCompact ?:boolean
+  title :string;
 };
 
 const CaseHistoryList = ({
   addCaseToPSA,
-  removeCaseFromPSA,
-  caseNumbersToAssociationId,
-  title,
   caseHistory,
   chargeHistory,
+  caseNumbersToAssociationId,
+  isCompact,
   loading,
+  modal,
   pendingCases,
   psaPermissions,
-  modal,
-  isCompact
+  removeCaseFromPSA,
+  title,
 } :Props) => {
   const addCaseToPSAButton = (caseEKID, caseNum) => {
     const associationEKID = caseNumbersToAssociationId.get(caseNum);
@@ -169,11 +169,11 @@ const CaseHistoryList = ({
             { caseNumbersToAssociationId ? addCaseToPSAButton(caseEKID, caseId) : null }
           </InfoRow>
           <ChargeList
+              charges={charges}
+              detailed
               isCompact={isCompact}
               modal={modal}
-              pretrialCaseDetails={caseObj}
-              charges={charges}
-              detailed />
+              pretrialCaseDetails={caseObj} />
         </div>
       );
     });
@@ -212,12 +212,12 @@ const CaseHistoryList = ({
 };
 
 CaseHistoryList.defaultProps = {
-  modal: false,
-  isCompact: false,
   addCaseToPSA: () => {},
-  removeCaseFromPSA: () => {},
+  isCompact: false,
+  modal: false,
   pendingCases: false,
   psaPermissions: false,
+  removeCaseFromPSA: () => {},
 };
 
 export default CaseHistoryList;

--- a/src/components/casehistory/ChargeHistoryStats.js
+++ b/src/components/casehistory/ChargeHistoryStats.js
@@ -2,13 +2,18 @@
  * @flow
  */
 import React from 'react';
-import Immutable from 'immutable';
+import { List, Map } from 'immutable';
 import { Tag } from 'lattice-ui-kit';
+import { DateTime } from 'luxon';
 
+import { PSA_NEIGHBOR } from '../../utils/consts/FrontEndStateConsts';
+import { APP_TYPES, PROPERTY_TYPES } from '../../utils/consts/DataModelConsts';
 import { getSummaryStats } from '../../utils/HistoricalChargeUtils';
+import { getChargeIdToSentenceDate } from '../../utils/SentenceUtils';
+import { getEntityProperties } from '../../utils/DataUtils';
+import { getPendingCharges } from '../../utils/AutofillUtils';
 import {
   Title,
-  PendingChargeStatus,
   StatsContainer,
   StatsWrapper,
   StatsSubWrapper,
@@ -19,91 +24,126 @@ import {
   StatsSectionHeader
 } from '../../utils/Layout';
 
+const {
+  CHARGES,
+  MANUAL_PRETRIAL_CASES,
+  PRETRIAL_CASES,
+  SENTENCES,
+} = APP_TYPES;
+
+const {
+  ARREST_DATE_TIME,
+  FILE_DATE,
+  CASE_ID
+} = PROPERTY_TYPES;
+
 type Props = {
-  chargeHistory :Immutable.Map<*, *>,
-  pendingCharges :Immutable.List<*, *>,
-  padding :boolean
+  padding :boolean;
+  personNeighbors :Map;
+  psaNeighbors :Map;
 };
 
-class ChargeHistoryStats extends React.Component<Props, *> {
+const ChargeHistoryStats = ({
+  personNeighbors,
+  psaNeighbors,
+  padding
+} :Props) => {
+  const arrest = psaNeighbors.getIn([MANUAL_PRETRIAL_CASES, PSA_NEIGHBOR.DETAILS], Map());
+  const {
+    [ARREST_DATE_TIME]: arrestDateTime,
+    [FILE_DATE]: arrestFileDate,
+    [CASE_ID]: caseId
+  } = getEntityProperties(
+    arrest,
+    [CASE_ID, ARREST_DATE_TIME, FILE_DATE]
+  );
+  const arrestDate = arrestDateTime || arrestFileDate || DateTime.local().toISO();
 
-  renderPendingChargeStatus = () => {
-    const { pendingCharges } = this.props;
-    const statusText = pendingCharges.size
-      ? `${pendingCharges.size} Pending Charge${pendingCharges.size > 1 ? 's' : ''}`
-      : 'No Pending Charges';
-    const mode = pendingCharges.size ? 'danger' : 'neutral';
-    return (
-      <Tag mode={mode}>
-        {statusText}
-      </Tag>
-    );
-  }
+  const allCharges = personNeighbors.get(CHARGES, List());
+  const allCases = personNeighbors.get(PRETRIAL_CASES, List());
+  const allSentences = personNeighbors.get(SENTENCES, List());
 
-  render() {
-    const { chargeHistory, padding, pendingCharges } = this.props;
-    const {
-      numMisdemeanorCharges,
-      numMisdemeanorConvictions,
-      numFelonyCharges,
-      numFelonyConvictions,
-      numViolentCharges,
-      numViolentConvictions
-    } = getSummaryStats(chargeHistory);
+  const chargeIdsToSentenceDates = getChargeIdToSentenceDate(allSentences);
+  const pendingCharges = getPendingCharges(
+    caseId,
+    arrestDate,
+    allCases,
+    allCharges,
+    allSentences
+  );
 
-    const SUMMARY_STATS_ARR = [
-      {
-        label: '# of misdemeanor charges',
-        value: numMisdemeanorCharges
-      },
-      {
-        label: '# of felony charges',
-        value: numFelonyCharges
-      },
-      {
-        label: '# of violent charges',
-        value: numViolentCharges
-      },
-      {
-        label: '# of misdemeanor convictions',
-        value: numMisdemeanorConvictions
-      },
-      {
-        label: '# of felony convictions',
-        value: numFelonyConvictions
-      },
-      {
-        label: '# of violent convictions',
-        value: numViolentConvictions
-      }
-    ];
+  const statusText = pendingCharges.size
+    ? `${pendingCharges.size} Pending Charge${pendingCharges.size > 1 ? 's' : ''}`
+    : 'No Pending Charges';
+  const mode = pendingCharges.size ? 'danger' : 'neutral';
 
-    const SummaryStats = SUMMARY_STATS_ARR.map((stat) => (
-      <StatsItem key={stat.label}>
-        <StatLabel>{stat.label}</StatLabel>
-        <StatValue>{stat.value}</StatValue>
-      </StatsItem>
-    ));
+  const {
+    numMisdemeanorCharges,
+    numMisdemeanorConvictions,
+    numFelonyCharges,
+    numFelonyConvictions,
+    numViolentCharges,
+    numViolentConvictions
+  } = getSummaryStats(allCharges, chargeIdsToSentenceDates);
 
-    return (
-      <StatsWrapper padding={padding}>
-        <StatsSectionHeader>
-          <Title withSubtitle>
-            <span>Summary Statistics</span>
-            All current and past cases
-          </Title>
-          {pendingCharges.size ? this.renderPendingChargeStatus() : null}
-        </StatsSectionHeader>
-        <StatsContainer>
-          <StatsSubWrapper>
-            <StatsGroup>
-              {SummaryStats}
-            </StatsGroup>
-          </StatsSubWrapper>
-        </StatsContainer>
-      </StatsWrapper>
-    );
-  }
-}
+  const SUMMARY_STATS_ARR = [
+    {
+      label: '# of misdemeanor charges',
+      value: numMisdemeanorCharges
+    },
+    {
+      label: '# of felony charges',
+      value: numFelonyCharges
+    },
+    {
+      label: '# of violent charges',
+      value: numViolentCharges
+    },
+    {
+      label: '# of misdemeanor convictions',
+      value: numMisdemeanorConvictions
+    },
+    {
+      label: '# of felony convictions',
+      value: numFelonyConvictions
+    },
+    {
+      label: '# of violent convictions',
+      value: numViolentConvictions
+    }
+  ];
+
+  const SummaryStats = SUMMARY_STATS_ARR.map((stat) => (
+    <StatsItem key={stat.label}>
+      <StatLabel>{stat.label}</StatLabel>
+      <StatValue>{stat.value}</StatValue>
+    </StatsItem>
+  ));
+
+  return (
+    <StatsWrapper padding={padding}>
+      <StatsSectionHeader>
+        <Title withSubtitle>
+          <span>Summary Statistics</span>
+          All current and past cases
+        </Title>
+        {
+          !!pendingCharges.size && (
+            <Tag mode={mode}>
+              {statusText}
+            </Tag>
+          )
+        }
+      </StatsSectionHeader>
+      <StatsContainer>
+        <StatsSubWrapper>
+          <StatsGroup>
+            {SummaryStats}
+          </StatsGroup>
+        </StatsSubWrapper>
+      </StatsContainer>
+    </StatsWrapper>
+  );
+};
 
 export default ChargeHistoryStats;

--- a/src/components/casehistory/ChargeHistoryStats.js
+++ b/src/components/casehistory/ChargeHistoryStats.js
@@ -38,7 +38,7 @@ const {
 } = PROPERTY_TYPES;
 
 type Props = {
-  padding :?boolean;
+  padding ?:boolean;
   personNeighbors :Map;
   psaNeighbors :Map;
 };

--- a/src/components/casehistory/ChargeHistoryStats.js
+++ b/src/components/casehistory/ChargeHistoryStats.js
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import Immutable from 'immutable';
+import { Tag } from 'lattice-ui-kit';
 
 import { getSummaryStats } from '../../utils/HistoricalChargeUtils';
 import {
@@ -31,10 +32,11 @@ class ChargeHistoryStats extends React.Component<Props, *> {
     const statusText = pendingCharges.size
       ? `${pendingCharges.size} Pending Charge${pendingCharges.size > 1 ? 's' : ''}`
       : 'No Pending Charges';
+    const mode = pendingCharges.size ? 'danger' : 'neutral';
     return (
-      <PendingChargeStatus pendingCharges={pendingCharges.size}>
+      <Tag mode={mode}>
         {statusText}
-      </PendingChargeStatus>
+      </Tag>
     );
   }
 

--- a/src/components/casehistory/ChargeHistoryStats.js
+++ b/src/components/casehistory/ChargeHistoryStats.js
@@ -38,7 +38,7 @@ const {
 } = PROPERTY_TYPES;
 
 type Props = {
-  padding :boolean;
+  padding :?boolean;
   personNeighbors :Map;
   psaNeighbors :Map;
 };
@@ -144,6 +144,10 @@ const ChargeHistoryStats = ({
       </StatsContainer>
     </StatsWrapper>
   );
+};
+
+ChargeHistoryStats.defaultProps = {
+  padding: false
 };
 
 export default ChargeHistoryStats;

--- a/src/components/review/PSAModalSummary.js
+++ b/src/components/review/PSAModalSummary.js
@@ -56,22 +56,21 @@ const NotesWrapper = styled.div`
 
 type Props = {
   addCaseToPSA :() => void;
-  removeCaseFromPSA :() => void;
   caseContext :string;
   caseNumbersToAssociationId :List;
   chargeHistoryForMostRecentPSA :Map;
   caseHistoryForMostRecentPSA :List;
-  notes :string;
-  neighbors :Map;
   manualCaseHistory :List;
-  chargeHistory :List;
   manualChargeHistory :Map;
-  pendingCharges :List;
+  neighbors :Map;
+  notes :string;
+  personNeighbors :Map;
+  psaPermissions :boolean;
   selectedOrganizationId :string;
   settings :Map;
+  removeCaseFromPSA :() => void;
   violentArrestCharges :Map;
   violentCourtCharges :Map;
-  psaPermissions :boolean;
 };
 
 class PSAModalSummary extends React.Component<Props, *> {
@@ -146,10 +145,9 @@ class PSAModalSummary extends React.Component<Props, *> {
 
   render() {
     const {
-      chargeHistory,
       neighbors,
       notes,
-      pendingCharges,
+      personNeighbors,
       settings
     } = this.props;
     const pretrialCase = getNeighborDetailsForEntitySet(neighbors, MANUAL_PRETRIAL_CASES);
@@ -171,8 +169,8 @@ class PSAModalSummary extends React.Component<Props, *> {
             ? (
               <ChargeHistoryStats
                   padding
-                  pendingCharges={pendingCharges}
-                  chargeHistory={chargeHistory} />
+                  personNeighbors={personNeighbors}
+                  psaNeighbors={neighbors} />
 
             ) : null
         }

--- a/src/containers/psamodal/PSAModal.js
+++ b/src/containers/psamodal/PSAModal.js
@@ -29,7 +29,7 @@ import RCMExplanation from '../../components/rcm/RCMExplanation';
 import SelectHearingsContainer from '../hearings/SelectHearingsContainer';
 import { getScoresAndRiskFactors, calculateRCM } from '../../utils/ScoringUtils';
 import { CenteredContainer, Title } from '../../utils/Layout';
-import { getCasesForPSA, currentPendingCharges } from '../../utils/CaseUtils';
+import { getCasesForPSA } from '../../utils/CaseUtils';
 import { RCM_FIELDS } from '../../utils/consts/RCMResultsConsts';
 import { OL } from '../../utils/consts/Colors';
 import { psaIsClosed } from '../../utils/PSAUtils';
@@ -77,7 +77,6 @@ const {
 } = RCM_FIELDS;
 
 const {
-  CHARGES,
   MANUAL_PRETRIAL_CASES,
   OUTCOMES,
   PEOPLE,

--- a/src/utils/DataUtils.js
+++ b/src/utils/DataUtils.js
@@ -28,14 +28,20 @@ export const getFirstNeighborValue = (neighborObj :Map, fqn :string, defaultValu
   neighborObj.getIn([fqn, 0], neighborObj.get(fqn, defaultValue))
 );
 
+export const getNeighborValueList = (neighborObj :Map, fqn :string, defaultValue :any = List()) => neighborObj.getIn(
+  [PSA_NEIGHBOR.DETAILS, fqn],
+  neighborObj.get(fqn, defaultValue)
+).filter((val) => !!val);
+
 // Pass entity object and list of property types and will return and object of labels
 // mapped to properties.
-export const getEntityProperties = (entityObj :Map, propertyList :string[]) => {
+export const getEntityProperties = (entityObj :Map, propertyList :string[], valueList ?:boolean = false) => {
   let returnPropertyFields = Map();
   if (propertyList.length) {
     propertyList.forEach((propertyType) => {
-      const backUpValue = entityObj.get(propertyType, '');
-      const property = getFirstNeighborValue(entityObj, propertyType, backUpValue);
+      const property = valueList
+        ? getNeighborValueList(entityObj, propertyType, List())
+        : getFirstNeighborValue(entityObj, propertyType, '');
       returnPropertyFields = returnPropertyFields.set(propertyType, property);
     });
   }

--- a/src/utils/HistoricalChargeUtils.js
+++ b/src/utils/HistoricalChargeUtils.js
@@ -3,12 +3,7 @@
  */
 
 import { DateTime } from 'luxon';
-import {
-  fromJS,
-  List,
-  Map,
-  Set
-} from 'immutable';
+import { List, Map, Set } from 'immutable';
 
 import { PLEAS_TO_IGNORE } from './consts/PleaConsts';
 import { PROPERTY_TYPES } from './consts/DataModelConsts';

--- a/src/utils/HistoricalChargeUtils.js
+++ b/src/utils/HistoricalChargeUtils.js
@@ -2,8 +2,13 @@
  * @flow
  */
 
-import { Map, List, Set } from 'immutable';
 import { DateTime } from 'luxon';
+import {
+  fromJS,
+  List,
+  Map,
+  Set
+} from 'immutable';
 
 import { PLEAS_TO_IGNORE } from './consts/PleaConsts';
 import { PROPERTY_TYPES } from './consts/DataModelConsts';
@@ -17,7 +22,6 @@ import {
 } from './consts/ChargeConsts';
 
 const {
-  ARREST_DATE,
   CHARGE_ID,
   CHARGE_DESCRIPTION,
   CHARGE_LEVEL,
@@ -37,9 +41,9 @@ type ChargeDetails = {
 
 const stripDegree = (chargeNum :string) :string => chargeNum.split('(')[0].trim();
 
-export const getCaseNumFromCharge = (charge :Map<*, *>) => charge.getIn([CHARGE_ID, 0], '').split('|')[0];
+export const getCaseNumFromCharge = (charge :Map) => charge.getIn([CHARGE_ID, 0], '').split('|')[0];
 
-export const getChargeDetails = (charge :Map<*, *>, ignoreCase? :boolean) :ChargeDetails => {
+export const getChargeDetails = (charge :Map, ignoreCase? :boolean) :ChargeDetails => {
   const caseNum :string = ignoreCase ? null : getCaseNumFromCharge(charge);
   const statute :string = formatValue(charge.get(CHARGE_STATUTE, List()));
   const description :string = formatValue(charge.get(CHARGE_DESCRIPTION, List()));
@@ -52,23 +56,26 @@ export const getChargeDetails = (charge :Map<*, *>, ignoreCase? :boolean) :Charg
   };
 };
 
-export const shouldIgnoreCharge = (charge :Map<*, *>) => {
-  const severities = charge.get(CHARGE_LEVEL, List());
-  const pleas = charge.get(PLEA, List());
-  const poaCaseNums = charge.get(CHARGE_ID, List()).filter((caseNum) => caseNum.includes('POA'));
+export const shouldIgnoreCharge = (charge :Map) => {
+  const {
+    [CHARGE_LEVEL]: severities,
+    [PLEA]: pleas,
+    [CHARGE_ID]: chargeIds
+  } = getEntityProperties(charge, [CHARGE_LEVEL, PLEA, CHARGE_ID], true);
+  const poaCaseNums = chargeIds.filter((caseNum) => caseNum.includes('POA'));
   const poaPleas = pleas.filter((plea) => PLEAS_TO_IGNORE.includes(plea));
   return severities.includes('MO')
     || severities.includes('PO')
     || severities.includes('P')
-    || !!poaCaseNums.size
-    || !!poaPleas.size;
+    || poaCaseNums.length > 0
+    || poaPleas.length > 0;
 };
 
 export const chargeStatuteIsViolent = (chargeNum :string) :boolean => (
   ODYSSEY_VIOLENT_STATUTES.includes(stripDegree(chargeNum.toLowerCase()))
 );
 
-export const chargeIsViolent = (charge :Map<*, *>) :boolean => {
+export const chargeIsViolent = (charge :Map) :boolean => {
   if (shouldIgnoreCharge(charge)) return false;
   const { statute, description } = getChargeDetails(charge);
   const strippedStatute = stripDegree(statute.toLowerCase());
@@ -82,7 +89,7 @@ export const chargeIsViolent = (charge :Map<*, *>) :boolean => {
   );
 };
 
-export const chargeIsMostSerious = (charge :Map<*, *>, pretrialCase :Map<*, *>) => {
+export const chargeIsMostSerious = (charge :Map, pretrialCase :Map) => {
   let mostSerious = false;
 
   const {
@@ -96,19 +103,19 @@ export const chargeIsMostSerious = (charge :Map<*, *>, pretrialCase :Map<*, *>) 
   return mostSerious;
 };
 
-export const getUnique = (valueList :List<string>) :List<string> => (
+export const getUnique = (valueList :string[]) :string[] => (
   valueList.filter((val, index) => valueList.indexOf(val) === index)
 );
-export const getViolentChargeNums = (chargeFields :List<string>) :List<string> => (
+export const getViolentChargeNums = (chargeFields :string[]) :string[] => (
   getUnique(chargeFields.filter((charge) => charge && chargeStatuteIsViolent(charge)))
 );
-export const chargeFieldIsViolent = (chargeField :List<string>) => getViolentChargeNums(chargeField).size > 0;
+export const chargeFieldIsViolent = (chargeField :string[]) => getViolentChargeNums(chargeField).length > 0;
 
 export const dispositionIsGuilty = (disposition :string) :boolean => GUILTY_DISPOSITIONS.includes(disposition);
 
-export const dispositionFieldIsGuilty = (dispositionField :List<string>) :boolean => {
+export const dispositionFieldIsGuilty = (dispositionField :string[]) :boolean => {
   let guilty = false;
-  if (dispositionField.size) {
+  if (dispositionField.length) {
     dispositionField.forEach((disposition) => {
       if (dispositionIsGuilty(disposition)) guilty = true;
     });
@@ -118,7 +125,8 @@ export const dispositionFieldIsGuilty = (dispositionField :List<string>) :boolea
 
 export const chargeIsGuilty = (charge :Map) => {
   if (shouldIgnoreCharge(charge)) return false;
-  return dispositionFieldIsGuilty(charge.get(DISPOSITION, List()));
+  const { [DISPOSITION]: dispositionField } = getEntityProperties(charge, [DISPOSITION], true);
+  return dispositionFieldIsGuilty(dispositionField);
 };
 
 export const chargeSentenceWasPendingAtTimeOfArrest = (
@@ -127,7 +135,7 @@ export const chargeSentenceWasPendingAtTimeOfArrest = (
   chargeIdsToSentenceDates :Map
 ) => {
   if (shouldIgnoreCharge(charge)) return false;
-  const { [CHARGE_ID]: chargeId } = getEntityProperties(charge, [ARREST_DATE, CHARGE_ID]);
+  const { [CHARGE_ID]: chargeId } = getEntityProperties(charge, [CHARGE_ID]);
   const sentenceDateTime = DateTime.fromISO(chargeIdsToSentenceDates.get(chargeId, ''));
 
   return sentenceDateTime.isValid ? sentenceDateTime > DateTime.fromISO(arrestDate) : true;
@@ -137,9 +145,8 @@ export const convictionAndGuilty = (arrestDate :string, charge :Map, chargeIdsTo
   chargeIsGuilty(charge) && !chargeSentenceWasPendingAtTimeOfArrest(arrestDate, charge, chargeIdsToSentenceDates)
 );
 
-export const degreeFieldIsMisdemeanor = (degreeField :List<string>) :boolean => {
-
-  if (!degreeField || degreeField.isEmpty()) {
+export const degreeFieldIsMisdemeanor = (degreeField :string[]) :boolean => {
+  if (!degreeField || degreeField.length === 0) {
     return false;
   }
 
@@ -151,12 +158,13 @@ export const degreeFieldIsMisdemeanor = (degreeField :List<string>) :boolean => 
   );
 };
 
-export const chargeIsMisdemeanor = (charge :Map<*, *>) => {
+export const chargeIsMisdemeanor = (charge :Map) => {
   if (shouldIgnoreCharge(charge)) return false;
-  return degreeFieldIsMisdemeanor(charge.get(PROPERTY_TYPES.CHARGE_LEVEL, List()));
+  const { [CHARGE_LEVEL]: degreeField } = getEntityProperties(charge, [CHARGE_LEVEL], true);
+  return degreeFieldIsMisdemeanor(degreeField);
 };
 
-export const degreeFieldIsFelony = (degreeField :List<string>) :boolean => {
+export const degreeFieldIsFelony = (degreeField :string[]) :boolean => {
   let result = false;
   degreeField.forEach((degree) => {
     if (degree && degree.toLowerCase().startsWith('f')) result = true;
@@ -164,12 +172,12 @@ export const degreeFieldIsFelony = (degreeField :List<string>) :boolean => {
   return result;
 };
 
-export const chargeIsFelony = (charge :Map<*, *>) => {
+export const chargeIsFelony = (charge :Map) => {
   if (shouldIgnoreCharge(charge)) return false;
   return degreeFieldIsFelony(charge.get(PROPERTY_TYPES.CHARGE_LEVEL, List()));
 };
 
-export const getChargeTitle = (charge :Map<*, *>, hideCase ?:boolean) :string => {
+export const getChargeTitle = (charge :Map, hideCase ?:boolean) :string => {
   const {
     caseNum,
     statute,
@@ -187,7 +195,7 @@ export const getChargeTitle = (charge :Map<*, *>, hideCase ?:boolean) :string =>
   return val;
 };
 
-export const getSummaryStats = (chargesByCaseNum :Map<*>) => {
+export const getSummaryStats = (allCharges :Map, chargeIdsToSentenceDates :Map) => {
   let numMisdemeanorCharges = 0;
   let numMisdemeanorConvictions = 0;
   let numFelonyCharges = 0;
@@ -195,27 +203,32 @@ export const getSummaryStats = (chargesByCaseNum :Map<*>) => {
   let numViolentCharges = 0;
   let numViolentConvictions = 0;
 
-  chargesByCaseNum.valueSeq().forEach((chargeList) => {
-    chargeList.forEach((charge) => {
-      const degreeField = charge.get(CHARGE_LEVEL, List()).filter((val) => !!val);
-      const chargeField = charge.get(CHARGE_STATUTE, List()).filter((val) => !!val);
-      const convicted = dispositionFieldIsGuilty(
-        charge.get(DISPOSITION, List()).filter((val) => !!val)
-      );
-      if (degreeFieldIsMisdemeanor(degreeField)) {
-        numMisdemeanorCharges += 1;
-        if (convicted) numMisdemeanorConvictions += 1;
-      }
-      else if (degreeFieldIsFelony(degreeField)) {
-        numFelonyCharges += 1;
-        if (convicted) numFelonyConvictions += 1;
-      }
-
-      if (chargeFieldIsViolent(chargeField)) {
-        numViolentCharges += 1;
-        if (convicted) numViolentConvictions += 1;
-      }
+  allCharges.forEach((charge) => {
+    const {
+      [CHARGE_ID]: chargeIdField,
+      [CHARGE_LEVEL]: degreeField,
+      [CHARGE_STATUTE]: chargeField,
+      [DISPOSITION]: dispositionField,
+    } = getEntityProperties(charge, [CHARGE_ID, CHARGE_LEVEL, CHARGE_STATUTE, DISPOSITION], true);
+    const convicted = dispositionFieldIsGuilty(dispositionField);
+    const chargeHasSentenceDate = chargeIdField.some((chargeId) => {
+      const hasSentenceDate = !!chargeIdsToSentenceDates.get(chargeId);
+      return hasSentenceDate;
     });
+
+    if (degreeFieldIsMisdemeanor(degreeField)) {
+      numMisdemeanorCharges += 1;
+      if (chargeHasSentenceDate && convicted) numMisdemeanorConvictions += 1;
+    }
+    else if (degreeFieldIsFelony(degreeField)) {
+      numFelonyCharges += 1;
+      if (chargeHasSentenceDate && convicted) numFelonyConvictions += 1;
+    }
+
+    if (chargeFieldIsViolent(chargeField)) {
+      numViolentCharges += 1;
+      if (chargeHasSentenceDate && convicted) numViolentConvictions += 1;
+    }
   });
 
   return {

--- a/src/utils/HistoricalChargeUtils.test.js
+++ b/src/utils/HistoricalChargeUtils.test.js
@@ -184,13 +184,13 @@ describe('HistoricalChargeUtils', () => {
     describe('chargeFieldIsViolent', () => {
 
       test('should correctly identify violent statute fields as violent', () => {
-        expect(chargeFieldIsViolent(Immutable.List.of(VIOLENT_F_STATUTE))).toEqual(true);
-        expect(chargeFieldIsViolent(Immutable.List.of(VIOLENT_M_STATUTE))).toEqual(true);
+        expect(chargeFieldIsViolent([VIOLENT_F_STATUTE])).toEqual(true);
+        expect(chargeFieldIsViolent([VIOLENT_M_STATUTE])).toEqual(true);
       });
 
       test('should correctly identify nonviolent statute fields as nonviolent', () => {
-        expect(chargeFieldIsViolent(Immutable.List.of(MISD_STATUTE))).toEqual(false);
-        expect(chargeFieldIsViolent(Immutable.List.of(FEL_STATUTE))).toEqual(false);
+        expect(chargeFieldIsViolent([MISD_STATUTE])).toEqual(false);
+        expect(chargeFieldIsViolent([FEL_STATUTE])).toEqual(false);
       });
 
     });
@@ -218,29 +218,29 @@ describe('HistoricalChargeUtils', () => {
     describe('getViolentChargeNums', () => {
 
       test('should return violent charge statutes from a list', () => {
-        expect(getViolentChargeNums(Immutable.List.of(
+        expect(getViolentChargeNums([
           VIOLENT_M_STATUTE,
           VIOLENT_M_STATUTE
-        ))).toEqual(Immutable.List.of(VIOLENT_M_STATUTE));
-        expect(getViolentChargeNums(Immutable.List.of(
+        ])).toEqual([VIOLENT_M_STATUTE]);
+        expect(getViolentChargeNums([
           VIOLENT_M_STATUTE,
           VIOLENT_M_STATUTE,
           VIOLENT_F_STATUTE
-        ))).toEqual(Immutable.List.of(VIOLENT_M_STATUTE, VIOLENT_F_STATUTE));
-        expect(getViolentChargeNums(Immutable.List.of(
+        ])).toEqual([VIOLENT_M_STATUTE, VIOLENT_F_STATUTE]);
+        expect(getViolentChargeNums([
           VIOLENT_M_STATUTE,
           MISD_STATUTE,
           VIOLENT_M_STATUTE,
           VIOLENT_F_STATUTE
-        ))).toEqual(Immutable.List.of(VIOLENT_M_STATUTE, VIOLENT_F_STATUTE));
-        expect(getViolentChargeNums(Immutable.List.of(
+        ])).toEqual([VIOLENT_M_STATUTE, VIOLENT_F_STATUTE]);
+        expect(getViolentChargeNums([
           FEL_STATUTE,
           VIOLENT_M_STATUTE,
           VIOLENT_M_STATUTE,
           MISD_STATUTE,
           VIOLENT_F_STATUTE,
           FEL_STATUTE
-        ))).toEqual(Immutable.List.of(VIOLENT_M_STATUTE, VIOLENT_F_STATUTE));
+        ])).toEqual([VIOLENT_M_STATUTE, VIOLENT_F_STATUTE]);
       });
 
     });
@@ -252,15 +252,15 @@ describe('HistoricalChargeUtils', () => {
     describe('degreeFieldIsMisdemeanor', () => {
 
       test('should correctly identify misdemeanor fields as misdemeanors', () => {
-        expect(degreeFieldIsMisdemeanor(Immutable.List.of('M1'))).toEqual(true);
-        expect(degreeFieldIsMisdemeanor(Immutable.List.of('M2'))).toEqual(true);
+        expect(degreeFieldIsMisdemeanor(['M1'])).toEqual(true);
+        expect(degreeFieldIsMisdemeanor(['M2'])).toEqual(true);
       });
 
       test('should correctly identify non-misdemeanor fields as non-misdemeanors', () => {
-        expect(degreeFieldIsMisdemeanor(Immutable.List.of('MO'))).toEqual(false);
-        expect(degreeFieldIsMisdemeanor(Immutable.List.of('F1'))).toEqual(false);
-        expect(degreeFieldIsMisdemeanor(Immutable.List.of('F6'))).toEqual(false);
-        expect(degreeFieldIsMisdemeanor(Immutable.List.of('FA'))).toEqual(false);
+        expect(degreeFieldIsMisdemeanor(['MO'])).toEqual(false);
+        expect(degreeFieldIsMisdemeanor(['F1'])).toEqual(false);
+        expect(degreeFieldIsMisdemeanor(['F6'])).toEqual(false);
+        expect(degreeFieldIsMisdemeanor(['FA'])).toEqual(false);
       });
 
     });
@@ -292,23 +292,23 @@ describe('HistoricalChargeUtils', () => {
     describe('degreeFieldIsFelony', () => {
 
       test('should correctly identify felony fields as felonies', () => {
-        expect(degreeFieldIsFelony(Immutable.List.of('F1'))).toEqual(true);
-        expect(degreeFieldIsFelony(Immutable.List.of('F2'))).toEqual(true);
-        expect(degreeFieldIsFelony(Immutable.List.of('F3'))).toEqual(true);
-        expect(degreeFieldIsFelony(Immutable.List.of('F4'))).toEqual(true);
-        expect(degreeFieldIsFelony(Immutable.List.of('F5'))).toEqual(true);
-        expect(degreeFieldIsFelony(Immutable.List.of('F6'))).toEqual(true);
-        expect(degreeFieldIsFelony(Immutable.List.of('FA'))).toEqual(true);
-        expect(degreeFieldIsFelony(Immutable.List.of('FB'))).toEqual(true);
-        expect(degreeFieldIsFelony(Immutable.List.of('FC'))).toEqual(true);
-        expect(degreeFieldIsFelony(Immutable.List.of('F'))).toEqual(true);
+        expect(degreeFieldIsFelony(['F1'])).toEqual(true);
+        expect(degreeFieldIsFelony(['F2'])).toEqual(true);
+        expect(degreeFieldIsFelony(['F3'])).toEqual(true);
+        expect(degreeFieldIsFelony(['F4'])).toEqual(true);
+        expect(degreeFieldIsFelony(['F5'])).toEqual(true);
+        expect(degreeFieldIsFelony(['F6'])).toEqual(true);
+        expect(degreeFieldIsFelony(['FA'])).toEqual(true);
+        expect(degreeFieldIsFelony(['FB'])).toEqual(true);
+        expect(degreeFieldIsFelony(['FC'])).toEqual(true);
+        expect(degreeFieldIsFelony(['F'])).toEqual(true);
       });
 
       test('should correctly identify non-felony fields as non-felonies', () => {
-        expect(degreeFieldIsFelony(Immutable.List.of('MO'))).toEqual(false);
-        expect(degreeFieldIsFelony(Immutable.List.of('M1'))).toEqual(false);
-        expect(degreeFieldIsFelony(Immutable.List.of('M2'))).toEqual(false);
-        expect(degreeFieldIsFelony(Immutable.List.of('P'))).toEqual(false);
+        expect(degreeFieldIsFelony(['MO'])).toEqual(false);
+        expect(degreeFieldIsFelony(['M1'])).toEqual(false);
+        expect(degreeFieldIsFelony(['M2'])).toEqual(false);
+        expect(degreeFieldIsFelony(['P'])).toEqual(false);
       });
 
     });
@@ -356,15 +356,15 @@ describe('HistoricalChargeUtils', () => {
     describe('dispositionFieldIsGuilty', () => {
 
       test('should correctly identify guilty disposition fields as guilty', () => {
-        expect(dispositionFieldIsGuilty(Immutable.List.of(GUILTY_DISP_1))).toEqual(true);
-        expect(dispositionFieldIsGuilty(Immutable.List.of(GUILTY_DISP_2))).toEqual(true);
-        expect(dispositionFieldIsGuilty(Immutable.List.of(GUILTY_DISP_3))).toEqual(true);
+        expect(dispositionFieldIsGuilty([GUILTY_DISP_1])).toEqual(true);
+        expect(dispositionFieldIsGuilty([GUILTY_DISP_2])).toEqual(true);
+        expect(dispositionFieldIsGuilty([GUILTY_DISP_3])).toEqual(true);
       });
 
       test('should correctly identify not guilty disposition fields as not guilty', () => {
-        expect(dispositionFieldIsGuilty(Immutable.List.of(NOT_GUILTY_DISP_1))).toEqual(false);
-        expect(dispositionFieldIsGuilty(Immutable.List.of(NOT_GUILTY_DISP_2))).toEqual(false);
-        expect(dispositionFieldIsGuilty(Immutable.List.of(NOT_GUILTY_DISP_3))).toEqual(false);
+        expect(dispositionFieldIsGuilty([NOT_GUILTY_DISP_1])).toEqual(false);
+        expect(dispositionFieldIsGuilty([NOT_GUILTY_DISP_2])).toEqual(false);
+        expect(dispositionFieldIsGuilty([NOT_GUILTY_DISP_3])).toEqual(false);
       });
 
     });

--- a/src/utils/Layout.js
+++ b/src/utils/Layout.js
@@ -437,6 +437,7 @@ export const StyledColumn = styled.div`
   display: flex;
   flex-direction: column;
   overflow: visble;
+  width: 100%;
 `;
 
 export const StyledColumnRowWrapper = styled.div`


### PR DESCRIPTION
We updated autofill utils a few months ago to use sentence date to determine which charges were pending and which charges the defendant was convicted for. That logic was not updated in the `ChargeHistoryStats` component, which was super confusing for some users. This PR updates the logic in that component. 